### PR TITLE
Adds a github action for building the docker image on merges to master

### DIFF
--- a/.github/workflows/build-and-push.yaml
+++ b/.github/workflows/build-and-push.yaml
@@ -1,0 +1,27 @@
+name: Build and Push Docker Image
+
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  docker:
+    runs-on: ubuntu-latest
+    name: Release Docker Image
+    steps:
+      - name: Get short SHA
+        id: slug
+        run: echo "::set-output name=sha8::$(echo ${GITHUB_SHA} | cut -c1-8)"
+      - name: Login to GCR
+        uses: docker/login-action@v1
+        with:
+          registry: gcr.io
+          username: _json_key
+          password: ${{ secrets.GCR_JSON_KEY }}
+      - name: Build & Push to Docker Hub
+        id: docker_build
+        uses: docker/build-push-action@v2
+        with:
+          push: true
+          tags: gcr.io/clingen-dev/curator:${{ steps.slug.outputs.sha8 }}


### PR DESCRIPTION
This will trigger a docker build and push it to GCR on updates to the master branch (both PR merges and direct commits to master will trigger this). Closes #5 .

This assumes that we have a Dockerfile in the root of the repository, so I think the other open PR has to merge first.

I still need to create the GCR service account, generate the key, and add it to this repository's Secrets in the settings.

Two things:

- does clingen have any sort of scripts or other config management code for creating service accounts, or are they generally created by hand?
- For docker images, I generally favor a promotion approach for moving releases from dev -> stg -> prod. By namespacing our docker image in a `clingen-dev` registry, it kind of necessitates that we build and deploy different images for each environment, rather than promote the same artifact. Both approaches will work, but I just want to make sure that we understand the distinction between the two approaches. I don't want to bog us down now with too many questions, so I'm happy to chat about this later.