### PR TITLE
Deploy to clingen-stage firebase on merges to master

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,11 @@
+# This is the dockerfile for executing yarn commands in the google cloudbuild,
+# prior to running the firebase deploy
+FROM ubuntu:20.04
+
+ARG DEBIAN_FRONTEND=noninteractive
+RUN apt-get update && apt-get install -y \
+  npm \
+  clojure \
+  && rm -rf /var/lib/apt/lists/*
+
+RUN npm install -g yarn

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -1,0 +1,5 @@
+steps:
+- name: gcr.io/clingen-stage/firebase
+  args: ['yarn', 'install']
+- name: gcr.io/clingen-stage/firebase
+  args: ['yarn', 'release']

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -5,3 +5,5 @@ steps:
 - name: 'gcr.io/clingen-stage/yarn-builder'
   entrypoint: 'yarn'
   args: ['release']
+- name: gcr.io/clingen-stage/firebase
+  args: ['deploy', '--project=clingen-stage', '--only=hosting']

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -1,5 +1,7 @@
 steps:
-- name: gcr.io/clingen-stage/firebase
-  args: ['yarn', 'install']
-- name: gcr.io/clingen-stage/firebase
-  args: ['yarn', 'release']
+- name: 'node'
+  entrypoint: 'yarn'
+  args: ['install']
+- name: 'node'
+  entrypoint: 'yarn'
+  args: ['release']

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -1,7 +1,7 @@
 steps:
-- name: 'node'
+- name: 'gcr.io/clingen-stage/yarn-builder'
   entrypoint: 'yarn'
   args: ['install']
-- name: 'node'
+- name: 'gcr.io/clingen-stage/yarn-builder'
   entrypoint: 'yarn'
   args: ['release']


### PR DESCRIPTION
I took one pass at this with Github Actions, and then realized that clingen tends to use google cloudbuild for things like this. The following is take 2, which has the advantage of not giving github any permissions to our GCP account.

This adds a cloudbuild.yaml file for running a yarn install, yarn release, and a firebase deploy. Also included is a Dockerfile -- due to our dependence on java/clojure, we couldn't utilize any of the existing nodejs/yarn official google cloudbuilder images without running a command to install the JDK on every step. This dockerfile is the source of the yarn-builder image in our GCR repsitory.

To configure this on the google end of things:

- I added a cloud build trigger: https://console.cloud.google.com/cloud-build/triggers/edit/e33e1d7e-c95f-4dfa-a2ca-6f01b4a2502b?project=clingen-stage which runs the build on pushes to the master branch
- I modified the cloudbuild serviceaccount in the clingen-stage project so that it also has the Firebase Admin and API Keys Admin role, per the docs: https://cloud.google.com/build/docs/deploying-builds/deploy-firebase#required_iam_permissions
- I built and uploaded the firebase community image into our GCR: https://github.com/GoogleCloudPlatform/cloud-builders-community/tree/master/firebase

Note that this will trigger a staging deployment when the PR is merged, so we should be careful to do it at a time where potential disruption in staging is okay.

Closes #5 