### PR TITLE
add some yarn arguments to make the install more appropriate for CI

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -1,7 +1,7 @@
 steps:
 - name: 'gcr.io/clingen-stage/yarn-builder'
   entrypoint: 'yarn'
-  args: ['install']
+  args: ['install', '--frozen-lockfile', '--non-interactive', '--no-progress']
 - name: 'gcr.io/clingen-stage/yarn-builder'
   entrypoint: 'yarn'
   args: ['release']


### PR DESCRIPTION
Realized when reviewing the staging deploy from 3/12 that we definitely want `--frozen-lockfile` to make sure that the staging deploy installs and deploys versions of what lives in the yarn.lock file. When reviewing other options, I decided that `--non-interactive` and `--no-progress` were probably better for a CI job, too.