### PR TITLE
Add initial version of parameterized deployments. 

### DIFF
--- a/shadow-cljs.edn
+++ b/shadow-cljs.edn
@@ -10,5 +10,10 @@
  :builds {:app {:output-dir "public/js"
                 :asset-path "/public/js"
                 :target :browser
+                :dev {:closure-defines {curator.BACKEND_USE_FIREBASE_CONFIG false
+                                        curator.BACKEND_HOST "localhost:8888"
+                                        curator.FIREBASE_CONFIG_NAME "clingen-dev"}}
+                :release {:closure-defines {curator.BACKEND_USE_FIREBASE_CONFIG true
+                                            curator.FIREBASE_CONFIG_NAME "clingen-stage"}}
                 ;; :js-options {:entry-keys ["module" "browser" "main"]}
                 :modules {:curator {:init-fn curator/init}}}}}

--- a/src/curator.cljs
+++ b/src/curator.cljs
@@ -53,7 +53,7 @@
               BACKEND_HOST)]
         (re-frame/dispatch [::re-graph/init
                             {:ws {:url (str "ws://" backend-host "/ws")}
-                             :http {:url "http://" backend-host "/api"}}]))))
+                             :http {:url (str "http://" backend-host "/api")}}]))))
   (routes/init-routes!)
   (-> (firebase/auth) (.onAuthStateChanged #(dispatch [:common/auth-state-change])))
   (mount-root))

--- a/src/curator.cljs
+++ b/src/curator.cljs
@@ -1,32 +1,33 @@
 (ns curator
-  (:require ["firebase/app" :as firebase]
+  (:require ["firebase" :as firebase]
+            ["firebase/app" :as firebase.app]
             ["firebase/auth"]
+            ;["firebase/remoteConfig" :as remote-config]
             [reagent.core :as reagent]
             [reagent.dom :as rdom]
             [re-frame.core :as re-frame :refer [subscribe dispatch]]
             [re-graph.core :as re-graph]
             [curator.pages.home.views :as home]
             [curator.common.views :as common-views]
-            [curator.routes :as routes]))
+            [curator.routes :as routes]
+            [curator.config :refer [firebase-config]]
+            [cljs.reader :as edn]
+            [clojure.core.async.interop]
+            ))
 
 (enable-console-print!)
 
-(def firebase-config
-  #js {:apiKey "AIzaSyCbBq1o5ZiVB5UflVNN-zCULAIRGgkHtrk"
-       :authDomain "clingen-stage.firebaseapp.com"
-       :databaseURL "https://clingen-stage.firebaseio.com"
-       :projectId "clingen-stage"
-       :storageBucket "clingen-stage.appspot.com"
-       :messagingSenderId "583560269534"
-       :appId "1:583560269534:web:b41fb5f1d09a6ef6fcbc4f"})
-
+(goog-define BACKEND_USE_FIREBASE_CONFIG false)
+(goog-define BACKEND_HOST "localhost:8888")
+(goog-define FIREBASE_CONFIG_NAME "clingen-dev")
 
 (defn ^:dev/after-load mount-root []
   (println "[main] reloaded lib:")
   (rdom/render [routes/router-component {:router routes/router}]
                (.getElementById js/document "app")))
 
-(re-frame/reg-event-db ::initialize-db
+(re-frame/reg-event-db
+  ::initialize-db
   (fn [db _]
     (if db
       db
@@ -34,10 +35,25 @@
 
 (defn ^:export init []
   (re-frame/dispatch-sync [::initialize-db])
-  (re-frame/dispatch [::re-graph/init 
-                      {:ws {:url "ws://localhost:8888/ws"}
-                       :http {:url "http://localhost:8888/api"}}])
-  (firebase/initializeApp firebase-config)
+  (let [app-config (get firebase-config (keyword FIREBASE_CONFIG_NAME))]
+    (js/console.log "app-config:" (clj->js app-config))
+    (firebase/initializeApp (clj->js app-config)))
+  (let [remote-config (.remoteConfig firebase)]
+    (js/console.log (str "use firebase config: " BACKEND_USE_FIREBASE_CONFIG))
+    (cljs.core.async/go
+      (let [backend-host
+            (if (= true BACKEND_USE_FIREBASE_CONFIG)
+              ; fetchAndActivate returns a javascript Promise which can be acquired using cljs async interop
+              (do (cljs.core.async.interop/<p! (.fetchAndActivate remote-config))
+                  ; remoteConfig.getValue returns a firebase.remoteconfig.Value object
+                  (let [remote-config-backend-host (-> firebase .remoteConfig (.getValue "BACKEND_HOST") .asString)]
+                    (.log js/console (str "got BACKEND_HOST from firebase remoteConfig: " remote-config-backend-host))
+                    remote-config-backend-host))
+              ; Default to the BACKEND_HOST defined locally
+              BACKEND_HOST)]
+        (re-frame/dispatch [::re-graph/init
+                            {:ws {:url (str "ws://" backend-host "/ws")}
+                             :http {:url "http://" backend-host "/api"}}]))))
   (routes/init-routes!)
   (-> (firebase/auth) (.onAuthStateChanged #(dispatch [:common/auth-state-change])))
   (mount-root))

--- a/src/curator/config.cljs
+++ b/src/curator/config.cljs
@@ -1,0 +1,16 @@
+(ns curator.config)
+
+(def firebase-config
+  {:clingen-dev {:apiKey "AIzaSyDj-cOdeUUNoaiA1DiUu9uLfRkrZ32TWJo",
+                 :authDomain "clingen-dev.firebaseapp.com",
+                 :projectId "clingen-dev",
+                 :storageBucket "clingen-dev.appspot.com",
+                 :messagingSenderId "522856288592",
+                 :appId "1:522856288592:web:d36446a53f898c80579c55"}
+   :clingen-stage {:apiKey "AIzaSyCbBq1o5ZiVB5UflVNN-zCULAIRGgkHtrk"
+                   :authDomain "clingen-stage.firebaseapp.com"
+                   :databaseURL "https://clingen-stage.firebaseio.com"
+                   :projectId "clingen-stage"
+                   :storageBucket "clingen-stage.appspot.com"
+                   :messagingSenderId "583560269534"
+                   :appId "1:583560269534:web:b41fb5f1d09a6ef6fcbc4f"}})


### PR DESCRIPTION
Can use either shadow-cljs.edn or Firebase RemoteConfig to specify the backend graphql server.